### PR TITLE
Fix apispec breaking change

### DIFF
--- a/flask_apispec/apidoc.py
+++ b/flask_apispec/apidoc.py
@@ -67,7 +67,6 @@ class Converter(object):
             options['default_in'] = self.get_default_in(locations[0])
         return converter(
             args.get('args', {}),
-            dump=False,
             **options
         ) + rule_to_params(rule, docs.get('params'))
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ REQUIRES = [
     'flask>=0.10.1',
     'marshmallow>=2.0',
     'webargs>=0.18.0',
-    'apispec>=0.4.1',
+    'apispec==0.20.0',
 ]
 
 def find_version(fname):


### PR DESCRIPTION
## Description

* https://github.com/marshmallow-code/apispec introduced a breaking change in a recent version (https://github.com/marshmallow-code/apispec/blob/dev/CHANGELOG.rst#0200-2017-03-19)
* In our `setup.py` we didn't have an upper bound for the version allowed for that dependency
* This PR modifies our code to comply with the breaking change, but also set a fixed version for that dependency in `setup.py`, so we have more control over updates to that package